### PR TITLE
Fix Ansible Galaxy tag formatting

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,7 +14,7 @@ license:
 tags:
   - application
   - palworld
-  - palworld-dedicated-server
+  - palworld_dedicated_server
 
 dependencies:
   community.docker: ">=3.6.0"


### PR DESCRIPTION
Tag slugs can only be lowercase alphanumerics or underscores.