### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This collection should make it easier to bring Palworld Dedicated Server
 under configuration management on dedicated hardware or an IaaS cloud instance,
 which is a recommended way of running Palworld as it is very resource intensive.
 
-Palworld Dedicated Server is configured to run as a Docker container on a standard machine,
+Palworld Dedicated Server is orchestrated as a Docker container on a standard machine,
 managed by Docker Compose. The Docker container used is
 [`jammsen/palworld-dedicated-server`](https://github.com/jammsen/docker-palworld-dedicated-server),
 a regularly maintained container for Palworld Dedicated Server with strong community support,

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ This collection should make it easier to bring Palworld Dedicated Server
 under configuration management on dedicated hardware or an IaaS cloud instance,
 which is a recommended way of running Palworld as it is very resource intensive.
 
-Palworld Dedicated Server will be run as a Docker container on a standard machine,
-managed by Docker Compose.
+Palworld Dedicated Server is configured to run as a Docker container on a standard machine,
+managed by Docker Compose. The Docker container used is
+[`jammsen/palworld-dedicated-server`](https://github.com/jammsen/docker-palworld-dedicated-server),
+a regularly maintained container for Palworld Dedicated Server with strong community support,
+that eliminates the usual manual setup steps required for configuring Palworld.
 
 ## Requirements
 
@@ -68,7 +71,7 @@ palworld_dedicated_server_settings:
 ```
 
 For more information on the available options, refer to the
-[environment variable documentation](https://github.com/jammsen/docker-palworld-dedicated-server/blob/master/default.env).
+[environment variable documentation](https://github.com/jammsen/docker-palworld-dedicated-server/blob/master/README_ENV.md).
 
 When setting a value here, **make sure the type of the value is correct in Ansible**,
 as the compose file template converts the values to environment variable definitions.

--- a/roles/disable/README.md
+++ b/roles/disable/README.md
@@ -1,4 +1,4 @@
-# `callum027.palworld_dedicated_server.stop`
+# `callum027.palworld_dedicated_server.disable`
 
 This stops the Palworld Dedicated Server service container, and deletes it
 so it cannot run on startup.

--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -1,4 +1,4 @@
-# `callum027.palworld_dedicated_server.stop`
+# `callum027.palworld_dedicated_server.install`
 
 This playbook creates the files and directories for Palworld Dedicated Server,
 starts the server, and configures it to run on startup.

--- a/roles/restart/README.md
+++ b/roles/restart/README.md
@@ -1,4 +1,4 @@
-# `callum027.palworld_dedicated_server.stop`
+# `callum027.palworld_dedicated_server.restart`
 
 This playbook restarts the Palworld Dedicated Service service container,
 without recreating it or modifying it in any way.

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -1,4 +1,4 @@
-# `callum027.palworld_dedicated_server.uninstall`
+# `callum027.palworld_dedicated_server.update`
 
 This playbook is similar to the `callum027.palworld_dedicated_server.install` role,
 except it will always update and recreate the Palworld Dedicated Server container image if there is an update available.


### PR DESCRIPTION
* Add a reference to the used Docker container [`jammsen/palworld-dedicated-server`](https://github.com/jammsen/docker-palworld-dedicated-server) in the README introdution
* Change the container environment variable documentation link to the actual document for configuring the environment variables
* Fix role name titles in the role README files