### PR TITLE
Add support for the Palworld Prometheus exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ managed by Docker Compose. The Docker container used is
 a regularly maintained container for Palworld Dedicated Server with strong community support,
 that eliminates the usual manual setup steps required for configuring Palworld.
 
-From version 1.1.0, this collection can optionally setup a
+From version 2.0.0, this collection can optionally setup a
 [Prometheus exporter for Palworld Dedicated Server (designed by palworld.lol)](https://github.com/palworldlol/palworld-exporter)
 alongside your server. This enables localised metrics collection from your dedeicated server,
 which can then be turned into dashboards using [Grafana](https://grafana.com).
@@ -51,7 +51,7 @@ The following inventory variables are **required** to be set on the hosts that P
 
 #### `palworld_dedicated_server_admin_password`
 
-*New in version 1.1.0.*
+*New in version 2.0.0.*
 
 Administrator password for the server.
 
@@ -65,7 +65,7 @@ palworld_dedicated_server_admin_password: "{{ vault_palworld_dedicated_server_ad
 
 #### `palworld_dedicated_server_settings`
 
-*Changed in version 1.1.0*: The `ADMIN_PASSWORD` field is no longer used by the collection.
+*Changed in version 2.0.0*: The `ADMIN_PASSWORD` field is no longer used by the collection.
 The administrator password for the dedicated server must now be set using the
 [`palworld_dedicated_server_admin_password`](#palworld_dedicated_server_admin_password) inventory variable.
 
@@ -137,28 +137,28 @@ The following variables are also available, with sane defaults already set. They
 * `palworld_dedicated_server_install_compose_file_group` - Assigned group of the compose file. Default is to use the value set for the install directory.
 * `palworld_dedicated_server_install_compose_file_mode` - Permissions for the compose file. Default is to use the value set for the install directory.
 * `palworld_dedicated_server_bind_address` - The local address to bind the Palworld Dedicated Server to. Default is `0.0.0.0` (bind to all interfaces).
-    * *New in version 1.1.0.*
+    * *New in version 2.0.0.*
 * `palworld_dedicated_server_bind_port` - The port to expose for connecting to the Palworld Dedicated Server. Default is `8211`.
-    * *Changed in version 1.1.0*: Renamed from `palworld_dedicated_server_public_port`.
+    * *Changed in version 2.0.0*: Renamed from `palworld_dedicated_server_public_port`.
 * `palworld_dedicated_server_rcon_enable` - When set to `true`, enable RCON port access to the Palworld Dedicated Server. Default is `false`.
 * `palworld_dedicated_server_rcon_bind_address` - Bind address for the RCON server. Set to `0.0.0.0` to allow access from other hosts on the network. Default is `127.0.0.1` (bind to `localhost`).
 * `palworld_dedicated_server_rcon_bind_port` - RCON access port. Default is `25575`.
-    * *Changed in version 1.1.0*: Renamed from `palworld_dedicated_server_rcon_port`.
+    * *Changed in version 2.0.0*: Renamed from `palworld_dedicated_server_rcon_port`.
 * `palworld_dedicated_server_rcon_wait_timeout` - Timeout for waiting for the RCON port to come online after the container starts, in seconds. This may need to be increased if the host's Internet connection is slow (as on the first run, the container takes a while to download Palworld after it starts). Default is `600`.
 * `palworld_dedicated_server_exporter_enable` - When set to `true`, orchestrate and start the Prometheus exporter for Palworld Dedicated Server. Default is `false`.
-    * *New in version 1.1.0.*
+    * *New in version 2.0.0.*
 * `palworld_dedicated_server_exporter_image_uri` - The URI for the image to install. Default is [`bostrt/palworld-exporter`](https://hub.docker.com/r/bostrt/palworld-exporter). **As this collection is designed around this image, this should not be changed.**
-    * *New in version 1.1.0.*
+    * *New in version 2.0.0.*
 * `palworld_dedicated_server_exporter_image_tag` - The image tag to install. Default is `latest`.
-    * *New in version 1.1.0.*
+    * *New in version 2.0.0.*
 * `palworld_dedicated_server_exporter_image_pull_policy` - The image pull policy to set for the Prometheus exporter. Default is to use the value of `palworld_dedicated_server_image_pull_policy`.
-    * *New in version 1.1.0.*
+    * *New in version 2.0.0.*
 * `palworld_dedicated_server_exporter_bind_address` - Bind address for the Prometheus exporter. You may want to override this to ensure it is only available on specific interfaces. Default is `0.0.0.0` (bind to all interfaces).
-    * *New in version 1.1.0.*
+    * *New in version 2.0.0.*
 * `palworld_dedicated_server_exporter_bind_port` - Prometheus exporter access port. Default is `9877`.
-    * *New in version 1.1.0.*
+    * *New in version 2.0.0.*
 * `palworld_dedicated_server_exporter_wait_timeout` - Timeout for waiting for the Prometheus exporter port to come online after the container starts, in seconds. Default is `300`.
-    * *New in version 1.1.0.*
+    * *New in version 2.0.0.*
 
 ## Playbooks
 

--- a/changelogs/fragments/2.0.0.yaml
+++ b/changelogs/fragments/2.0.0.yaml
@@ -1,0 +1,36 @@
+---
+
+release_summary: |
+  This release adds support for orchestrating a Prometheus exporter alongside the Palworld Dedicated Server.
+
+  Enable it by setting ``palworld_dedicated_server_exporter_enable`` to ``true``, and configure the bind IP address and port with ``palworld_dedicated_server_exporter_bind_address`` (defaults to ``0.0.0.0``) and ``palworld_dedicated_server_exporter_bind_port`` (defaults to ``9877``).
+
+  This is a major version upgrade as unfortunately a number of breaking changes were required in this release. In the future the necessity of major version releases like this should decrease.
+
+breaking_changes:
+  - The ``palworld_dedicated_server_public_port`` inventory variable has been renamed to ``palworld_dedicated_server_bind_port``.
+  - The ``palworld_dedicated_server_rcon_port`` inventory variable has been renamed to ``palworld_dedicated_server_rcon_bind_port``.
+  - >-
+    The Palworld server admin password is now set in the ``palworld_dedicated_server_admin_password`` inventory variable.
+    It can no longer be defined by setting ``ADMIN_PASSWORD`` in ``palworld_dedicated_server_settings`` (this value will now be ignored).
+
+major_changes:
+  - >-
+    Add support for orchestrating the `bostrt/palworld-exporter <https://hub.docker.com/r/bostrt/palworld-exporter>`_
+    Prometheus exporter, `developed by palworld.lol <https://github.com/palworldlol/palworld-exporter>`_,
+    alongside Palworld Dedicated Server.
+
+minor_changes:
+  - >-
+    The Palworld Dedicated Server's bind address for external access is now configurable using
+    ``palworld_dedicated_server_exporter_bind_address``, which defaults to ``0.0.0.0``.
+
+bugfixes:
+  - Fix syntax errors in the compose file causing the service start to error out when RCON is enabled.
+
+trivial:
+  - >-
+    Palworld will now be configured to always have RCON enabled internally. This for both local RCON CLI command access and enabling the Prometheus exporter.
+    When ``palworld_dedicated_server_rcon_enable`` is set to ``false``, external access to this endpoint is disabled, as it did previously.
+  - Add test job for building the Ansible Galaxy package (`#10 <https://github.com/Callum027/ansible-collection-palworld-dedicated-server/pull/10>`_)
+  - Add support for the Palworld Prometheus exporter (`#11 <https://github.com/Callum027/ansible-collection-palworld-dedicated-server/pull/11>`_)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: callum027
 name: palworld_dedicated_server
-version: 1.0.1
+version: 1.1.0
 authors:
   - Callum Dickinson <callum.dickinson.nz@gmail.com>
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: callum027
 name: palworld_dedicated_server
-version: 1.1.0
+version: 2.0.0
 authors:
   - Callum Dickinson <callum.dickinson.nz@gmail.com>
 

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -29,10 +29,10 @@ provisioner:
         palworld_dedicated_server_container_name: palworld-dedicated-server
     host_vars:
       palworld1:
+        palworld_dedicated_server_admin_password: "123456"
         palworld_dedicated_server_settings:
           SERVER_NAME: Palworld Dedicated Server Molecule Test
           SERVER_DESCRIPTION: Molecule test for Palworld Dedicated Server
-          ADMIN_PASSWORD: "123456"
           SERVER_PASSWORD: "123456"
           COMMUNITY_SERVER: false
 

--- a/molecule/localhost/molecule.yml
+++ b/molecule/localhost/molecule.yml
@@ -31,10 +31,10 @@ provisioner:
         palworld_dedicated_server_container_name: palworld-dedicated-server
     host_vars:
       localhost:
+        palworld_dedicated_server_admin_password: "123456"
         palworld_dedicated_server_settings:
           SERVER_NAME: Palworld Dedicated Server Molecule Test
           SERVER_DESCRIPTION: Molecule test for Palworld Dedicated Server
-          ADMIN_PASSWORD: "123456"
           SERVER_PASSWORD: "123456"
           COMMUNITY_SERVER: false
 

--- a/molecule/openstack/molecule.yml
+++ b/molecule/openstack/molecule.yml
@@ -26,10 +26,10 @@ provisioner:
         palworld_dedicated_server_container_name: palworld-dedicated-server
     host_vars:
       ${CI_PREFIX:-molecule-callum027-palworld_dedicated_server}-palworld1:
+        palworld_dedicated_server_admin_password: "123456"
         palworld_dedicated_server_settings:
           SERVER_NAME: Palworld Dedicated Server Molecule Test
           SERVER_DESCRIPTION: Molecule test for Palworld Dedicated Server
-          ADMIN_PASSWORD: "123456"
           SERVER_PASSWORD: "123456"
           COMMUNITY_SERVER: false
 

--- a/roles/common/defaults/main/bind.yml
+++ b/roles/common/defaults/main/bind.yml
@@ -1,0 +1,4 @@
+---
+
+palworld_dedicated_server_bind_address: "0.0.0.0"
+palworld_dedicated_server_bind_port: 8211

--- a/roles/common/defaults/main/exporter.yml
+++ b/roles/common/defaults/main/exporter.yml
@@ -1,0 +1,14 @@
+---
+
+palworld_dedicated_server_exporter_enable: false
+
+palworld_dedicated_server_exporter_image_uri: bostrt/palworld-exporter
+palworld_dedicated_server_exporter_image_tag: latest
+palworld_dedicated_server_exporter_image_pull_policy: "{{ palworld_dedicated_server_image_pull_policy }}"
+
+palworld_dedicated_server_exporter_container_name: null
+
+palworld_dedicated_server_exporter_bind_address: "0.0.0.0"
+palworld_dedicated_server_exporter_bind_port: 9877
+
+palworld_dedicated_server_exporter_wait_timeout: 300

--- a/roles/common/defaults/main/public.yml
+++ b/roles/common/defaults/main/public.yml
@@ -1,3 +1,0 @@
----
-
-palworld_dedicated_server_public_port: 8211

--- a/roles/common/defaults/main/rcon.yml
+++ b/roles/common/defaults/main/rcon.yml
@@ -5,6 +5,6 @@ palworld_dedicated_server_rcon_enable: false
 # Set to 0.0.0.0 for externally accessible RCON access
 # (not recommended unless you are on a private network).
 palworld_dedicated_server_rcon_bind_address: 127.0.0.1
-palworld_dedicated_server_rcon_port: 25575
+palworld_dedicated_server_rcon_bind_port: 25575
 
 palworld_dedicated_server_rcon_wait_timeout: 600

--- a/roles/common/defaults/main/settings.yml
+++ b/roles/common/defaults/main/settings.yml
@@ -1,5 +1,8 @@
 ---
 
+# Password to use when logging into server administration interfaces, such as RCON. **Required.**
+# palworld_dedicated_server_admin_password: "{{ vault_palworld_dedicated_server_admin_password }}"
+
 # When setting a value here, **make sure the type of the value is correct in Ansible**,
 # as the compose file template converts the value to an environment variable definition.
 #
@@ -14,7 +17,6 @@
 # The following values are either **required** or recommended to be changed:
 #
 #   * SERVER_NAME - Name of the Palworld Dedicated Server as shown in Palworld (**required**)
-#   * ADMIN_PASSWORD - Administrator password for the server (**required**)
 #   * SERVER_PASSWORD - Set the password required to access the server, or set to a blank string to not require a password (**required**)
 #   * SERVER_DESCRIPTION - Description of the server when viewed from Palworld (recommended)
 #   * PUBLIC_IP - Public IP address of the server, as accessible from the Internet (recommended)

--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -55,6 +55,11 @@
       when: not ansible_check_mode or (palworld_dedicated_server_temp_compose_file.stat.isreg | default(False))
     - name: Wait until the RCON port is open (if enabled)
       ansible.builtin.wait_for:
-        port: "{{ palworld_dedicated_server_rcon_port }}"
+        port: "{{ palworld_dedicated_server_rcon_bind_port }}"
         timeout: "{{ palworld_dedicated_server_rcon_wait_timeout }}"
       when: palworld_dedicated_server_rcon_enable
+    - name: Wait until the Prometheus exporter port is open (if enabled)
+      ansible.builtin.wait_for:
+        port: "{{ palworld_dedicated_server_exporter_bind_port }}"
+        timeout: "{{ palworld_dedicated_server_exporter_wait_timeout }}"
+      when: palworld_dedicated_server_exporter_enable

--- a/roles/install/templates/docker-compose.yml.j2
+++ b/roles/install/templates/docker-compose.yml.j2
@@ -3,6 +3,7 @@
 version: "3.7"
 
 services:
+  # Palworld Dedicated Server main process.
   palworld-dedicated-server:
     image: '{{ palworld_dedicated_server_image_uri }}:{{ palworld_dedicated_server_image_tag }}'
     pull_policy: '{{ palworld_dedicated_server_image_pull_policy }}'
@@ -16,25 +17,22 @@ services:
         target: /palworld
         read_only: false
     ports:
-      - published: {{ palworld_dedicated_server_public_port }}
-        target: 8211
-        protocol: udp
-        mode: host
+      - "{{ palworld_dedicated_server_bind_address }}:{{ palworld_dedicated_server_bind_port }}:8211/udp"
 {% if palworld_dedicated_server_rcon_enable %}
-      - published: {{ palworld_dedicated_server_rcon_bind_address }}:{{ palworld_dedicated_server_public_port }}
-        target: 25575
-        protocol: tcp
-        mode: host
+      - "{{ palworld_dedicated_server_rcon_bind_address }}:{{ palworld_dedicated_server_rcon_bind_port }}:25575"
 {% endif %}
     environment:
       - TZ={{ palworld_dedicated_server_container_timezone }}
       - PUID=1000
       - PGID=1000
       - SERVER_SETTINGS_MODE=auto
-      - RCON_ENABLED={{ palworld_dedicated_server_rcon_enable | string | lower }}
-      - RCON_PORT={{ palworld_dedicated_server_rcon_port }}
+      # Always enabled, to allow access using the local CLI command, and Palworld Exporter.
+      # External access is controlled through publishing the port.
+      - RCON_ENABLED=true
+      - RCON_PORT=25575
+      - ADMIN_PASSWORD={{ palworld_dedicated_server_admin_password }}
 {% for key, value in palworld_dedicated_server_settings.items() %}
-{% if key not in ["TZ", "PUID", "PGID", "SERVER_SETTINGS_MODE", "RCON_ENABLED", "RCON_PORT"] %}
+{% if key not in ["TZ", "PUID", "PGID", "SERVER_SETTINGS_MODE", "RCON_ENABLED", "RCON_PORT", "ADMIN_PASSWORD"] %}
 {% if value is boolean %}
       - {{ key }}={{ value | string | lower }}
 {% elif value is float %}
@@ -44,3 +42,21 @@ services:
 {% endif %}
 {% endif %}
 {% endfor %}
+{% if palworld_dedicated_server_exporter_enable %}
+  # Prometheus exporter for Palworld dedicated server.
+  palworld-exporter:
+    image: '{{ palworld_dedicated_server_exporter_image_uri }}:{{ palworld_dedicated_server_exporter_image_tag }}'
+    pull_policy: '{{ palworld_dedicated_server_exporter_image_pull_policy }}'
+    restart: always
+{% if palworld_dedicated_server_exporter_container_name %}
+    container_name: '{{ palworld_dedicated_server_exporter_container_name }}'
+{% endif %}
+    depends_on:
+      - palworld-dedicated-server
+    ports:
+      - "{{ palworld_dedicated_server_exporter_bind_address }}:{{ palworld_dedicated_server_exporter_bind_port }}:9877"
+    environment:
+      - RCON_HOST=palworld-dedicated-server
+      - RCON_PORT=25575
+      - RCON_PASSWORD={{ palworld_dedicated_server_admin_password }}
+{% endif %}


### PR DESCRIPTION
This PR adds support for orchestrating a Prometheus exporter alongside the Palworld Dedicated Server. The exporter is [developed by palworld.lol](https://github.com/palworldlol/palworld-exporter), and the tag on Docker Hub is [`bostrt/palworld-exporter`](https://hub.docker.com/r/bostrt/palworld-exporter).

Enable it by setting `palworld_dedicated_server_exporter_enable` to `true`, and configure the bind IP address and port with `palworld_dedicated_server_exporter_bind_address` (defaults to `0.0.0.0`) and `palworld_dedicated_server_exporter_bind_port` (defaults to `9877`).

There are a number of related changes that were necessary for this PR, unfortunately many of them are breaking. In the future the necessity of breaking changes like this should decrease.

**Breaking changes**:

* The `palworld_dedicated_server_public_port` inventory variable has been renamed to `palworld_dedicated_server_bind_port`.
* The `palworld_dedicated_server_rcon_port` inventory variable has been renamed to `palworld_dedicated_server_rcon_bind_port`.
* The Palworld server admin password is now set in the `palworld_dedicated_server_admin_password` inventory variable. It can no longer be defined by setting `ADMIN_PASSWORD` in `palworld_dedicated_server_settings` (this value will now be ignored).

Other changes:

* The Palworld Dedicated Server's bind address for external access is now configurable using `palworld_dedicated_server_exporter_bind_address`, which defaults to `0.0.0.0`.
* Palworld will now be configured to always have RCON enabled internally. This for both local RCON CLI command access and enabling the Prometheus exporter.
  * When `palworld_dedicated_server_rcon_enable` is set to `false`, external access to this endpoint is disabled, as it did previously.
* Fix syntax errors in the compose file when RCON access is enabled.