### PR TITLE
Fix release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "^[0-9]+.[0-9]+.[0-9]+$"
+      - "*.*.*"
 
 jobs:
   build:


### PR DESCRIPTION
Looks like regular expressions are not supported by `on.push.tags`, even though some places on the Internet say it does. It must be globs.