### PR TITLE
Update `actions/download-artifact` to `v4`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout release
         uses: actions/checkout@v4
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: callum027-palworld_dedicated_server-${{ github.ref_name }}.tar.gz
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout release
         uses: actions/checkout@v4
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: callum027-palworld_dedicated_server-${{ github.ref_name }}.tar.gz


### PR DESCRIPTION
Update to match the currently used version of `actions/upload-artifact`. The versions must match (they are not backwards compatible with the older versions).